### PR TITLE
fix: resolve Claude CLI absolute path with shutil.which

### DIFF
--- a/server.py
+++ b/server.py
@@ -13,6 +13,7 @@ import os
 import pty
 import re
 import select
+import shutil
 import signal
 import struct
 import termios
@@ -23,7 +24,7 @@ from pathlib import Path
 from aiohttp import web
 
 STATIC_DIR = Path(__file__).parent / "static"
-CLAUDE_CMD = os.environ.get("CLAUDE_CMD", "claude")
+CLAUDE_CMD = os.environ.get("CLAUDE_CMD", shutil.which("claude") or "claude")
 MY_PID = os.getpid()
 
 


### PR DESCRIPTION
## Summary
- PTY 자식 프로세스에서 `PATH`가 제한되어 `claude` 바이너리를 찾지 못하는 버그 수정
- `shutil.which("claude")`로 서버 시작 시 절대경로를 미리 resolve하도록 변경

Closes #1

## Test plan
- [ ] `python3 server.py`로 서버 시작
- [ ] 브라우저에서 세션 생성 후 Claude CLI 정상 실행 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)